### PR TITLE
Fixed bug where blank visitor id reverted to `example` on page refresh

### DIFF
--- a/chooseyourvisitor.html
+++ b/chooseyourvisitor.html
@@ -202,7 +202,6 @@
           </form>
         </div>
         <div id="user-feedback">
-          <p id="status-message">Waiting for agent</p>
           <p>
             Visitor ID: <span id="visitor-id"></span>
             <button type="button" id="change-visitor-id">
@@ -227,6 +226,7 @@
             <label for="auto-load-post-load">Auto load script?</label>
           </div>
           <div class="loader" id="loader"></div>
+          <p id="status-message">Waiting for agent</p>
         </div>
       </div>
     </section>

--- a/chooseyourvisitor.js
+++ b/chooseyourvisitor.js
@@ -284,7 +284,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
   if (environment) {
     document.getElementById("environment").value = environment;
   }
-  if (visitorId) {
+  if (visitorId != null) {
     document.getElementById("visitorId").value = visitorId;
   }
   if (website) {


### PR DESCRIPTION
Closes #58 